### PR TITLE
Replaced 'setField' by 'accessField'

### DIFF
--- a/src/test/java/JavaxEjbTests.java
+++ b/src/test/java/JavaxEjbTests.java
@@ -29,13 +29,16 @@ public class JavaxEjbTests {
             JavaAccess.Functions.Get.<JavaFieldAccess, AccessTarget.FieldAccessTarget>target()
                     .is(annotatedWith(EJB.class));
 
+    // I don't know for certain what your intention was, setField means explicitly "write to a field" i.e. what a Setter does
+    // Thus the class didn't violate this rule, as it only does 'getField', i.e. read from the field.
+    // 'accessField' just covers both, so it's probably, what you want?
     /**
      * False Positive. @EJB is set to Retention.RUNTIME, so should be OK?
      * @see org.superbiz.servlet.RunAsServlet
      * */
     @ArchTest
     public static final ArchRule noEjbAnnotatedFields = ArchRuleDefinition.priority(LOW)
-            .noClasses().should().setFieldWhere(TARGET_IS_EJB);
+            .noClasses().should().accessFieldWhere(TARGET_IS_EJB);
 
     @ArchTest
     public static final ArchRule noLocal = ArchRuleDefinition.priority(MEDIUM).noClasses()

--- a/src/test/java/JavaxPersistenceTests.java
+++ b/src/test/java/JavaxPersistenceTests.java
@@ -56,11 +56,11 @@ public class JavaxPersistenceTests {
      */
     @ArchTest
     public static final ArchRule noIdFields = ArchRuleDefinition.priority(LOW)
-            .noClasses().should().setFieldWhere(TARGET_IS_ID);
+            .noClasses().should().accessFieldWhere(TARGET_IS_ID);
 
     @ArchTest
     public static final ArchRule noColumnFields = ArchRuleDefinition.priority(LOW)
-            .noClasses().should().setFieldWhere(TARGET_IS_COLUMN);
+            .noClasses().should().accessFieldWhere(TARGET_IS_COLUMN);
 
     /**
      * False Positive. @Generated value is set to Retention.RUNTIME, so should be OK?
@@ -68,7 +68,7 @@ public class JavaxPersistenceTests {
      */
     @ArchTest
     public static final ArchRule noGeneratedValues = ArchRuleDefinition.priority(LOW)
-            .noClasses().should().setFieldWhere(TARGET_IS_GENERATED_VALUE);
+            .noClasses().should().accessFieldWhere(TARGET_IS_GENERATED_VALUE);
 
 
     /**
@@ -77,7 +77,7 @@ public class JavaxPersistenceTests {
      */
     @ArchTest
     public static final ArchRule noPersistenceUnits = ArchRuleDefinition.priority(LOW)
-            .noClasses().should().setFieldWhere(TARGET_IS_PERSISTENCE_UNIT);
+            .noClasses().should().accessFieldWhere(TARGET_IS_PERSISTENCE_UNIT);
 
 
 }


### PR DESCRIPTION
I think you probably wanted to test for any access to the field, not just "set" accesses? (set accesses only cover writing accesses to fields)