### PR TITLE
Alternative annotation approach

### DIFF
--- a/src/test/java/JavaxEjbTests.java
+++ b/src/test/java/JavaxEjbTests.java
@@ -29,13 +29,16 @@ public class JavaxEjbTests {
             JavaAccess.Functions.Get.<JavaFieldAccess, AccessTarget.FieldAccessTarget>target()
                     .is(annotatedWith(EJB.class));
 
+    // I don't know for certain what your intention was, setField means explicitly "write to a field" i.e. what a Setter does
+    // Thus the class didn't violate this rule, as it only does 'getField', i.e. read from the field.
+    // 'accessField' just covers both, so it's probably, what you want?
     /**
      * False Positive. @EJB is set to Retention.RUNTIME, so should be OK?
      * @see org.superbiz.servlet.RunAsServlet
      * */
     @ArchTest
     public static final ArchRule noEjbAnnotatedFields = ArchRuleDefinition.priority(LOW)
-            .noClasses().should().setFieldWhere(TARGET_IS_EJB);
+            .noClasses().should().accessFieldWhere(TARGET_IS_EJB);
 
     @ArchTest
     public static final ArchRule noLocal = ArchRuleDefinition.priority(MEDIUM).noClasses()

--- a/src/test/java/JavaxPersistenceTests.java
+++ b/src/test/java/JavaxPersistenceTests.java
@@ -1,24 +1,41 @@
-import com.tngtech.archunit.base.DescribedPredicate;
-import com.tngtech.archunit.core.domain.AccessTarget;
-import com.tngtech.archunit.core.domain.JavaAccess;
-import com.tngtech.archunit.core.domain.JavaFieldAccess;
-import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchIgnore;
-import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.junit.ArchUnitRunner;
-import com.tngtech.archunit.lang.ArchRule;
-import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
-import org.junit.runner.RunWith;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
 
 import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.PersistenceUnit;
 
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.AccessTarget;
+import com.tngtech.archunit.core.domain.JavaAccess;
+import com.tngtech.archunit.core.domain.JavaAnnotation;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaFieldAccess;
+import com.tngtech.archunit.core.domain.JavaMember;
+import com.tngtech.archunit.core.domain.properties.HasType;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchIgnore;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.lang.AbstractClassesTransformer;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ClassesTransformer;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.domain.Formatters.formatLocation;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_TYPE;
 import static com.tngtech.archunit.lang.Priority.LOW;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.no;
 
 @RunWith(ArchUnitRunner.class)
 @AnalyzeClasses(packages = "org.superbiz.servlet")
@@ -39,7 +56,6 @@ public class JavaxPersistenceTests {
     private static final DescribedPredicate<JavaFieldAccess> TARGET_IS_PERSISTENCE_UNIT =
             JavaAccess.Functions.Get.<JavaFieldAccess, AccessTarget.FieldAccessTarget>target()
                     .is(annotatedWith(PersistenceUnit.class));
-
 
     @ArchIgnore
     @ArchTest
@@ -70,7 +86,6 @@ public class JavaxPersistenceTests {
     public static final ArchRule noGeneratedValues = ArchRuleDefinition.priority(LOW)
             .noClasses().should().accessFieldWhere(TARGET_IS_GENERATED_VALUE);
 
-
     /**
      * False Positive. @PersistenceUnit is set to Retention.RUNTIME, so should be OK?
      * @see org.superbiz.servlet.JpaServlet
@@ -79,5 +94,52 @@ public class JavaxPersistenceTests {
     public static final ArchRule noPersistenceUnits = ArchRuleDefinition.priority(LOW)
             .noClasses().should().accessFieldWhere(TARGET_IS_PERSISTENCE_UNIT);
 
+    @ArchTest
+    public static final ArchRule noPersistenceAnnotationsOnMembers =
+            no(members()).should(beAnnotatedWithTypeIn("javax.persistence.."));
 
+    private static ClassesTransformer<JavaMember> members() {
+        return new AbstractClassesTransformer<JavaMember>("members") {
+            @Override
+            public Iterable<JavaMember> doTransform(JavaClasses javaClasses) {
+                Set<JavaMember> result = new HashSet<>();
+                for (JavaClass javaClass : javaClasses) {
+                    result.addAll(javaClass.getMembers());
+                }
+                return result;
+            }
+        };
+    }
+
+    private static ArchCondition<JavaMember> beAnnotatedWithTypeIn(final String packageIdentifier) {
+        return new ArchCondition<JavaMember>("be annotated with type in javax.persistence..") {
+            @Override
+            public void check(JavaMember javaMember, ConditionEvents conditionEvents) {
+                Set<JavaAnnotation> matchingAnnotations = getAnnotationsWithType(javaMember, packageIdentifier);
+                boolean satisfied = !matchingAnnotations.isEmpty();
+                String message = String.format("member %s is annotated with %s in %s",
+                        javaMember.getFullName(), toString(matchingAnnotations), formatLocation(javaMember.getOwner(), 0));
+                conditionEvents.add(new SimpleConditionEvent(javaMember, satisfied, message));
+            }
+
+            private Set<JavaAnnotation> getAnnotationsWithType(JavaMember javaMember, String packageIdentifier) {
+                final DescribedPredicate<HasType> inJavaxPersistence = GET_TYPE.is(resideInAPackage(packageIdentifier));
+                Set<JavaAnnotation> result = new HashSet<>();
+                for (JavaAnnotation annotation : javaMember.getAnnotations()) {
+                    if (inJavaxPersistence.apply(annotation)) {
+                        result.add(annotation);
+                    }
+                }
+                return result;
+            }
+
+            private Set<String> toString(Set<JavaAnnotation> matchingAnnotations) {
+                Set<String> result = new TreeSet<>();
+                for (JavaAnnotation annotation : matchingAnnotations) {
+                    result.add("@" + annotation.getType().getName());
+                }
+                return result;
+            }
+        };
+    }
 }

--- a/src/test/java/JavaxPersistenceTests.java
+++ b/src/test/java/JavaxPersistenceTests.java
@@ -56,11 +56,11 @@ public class JavaxPersistenceTests {
      */
     @ArchTest
     public static final ArchRule noIdFields = ArchRuleDefinition.priority(LOW)
-            .noClasses().should().setFieldWhere(TARGET_IS_ID);
+            .noClasses().should().accessFieldWhere(TARGET_IS_ID);
 
     @ArchTest
     public static final ArchRule noColumnFields = ArchRuleDefinition.priority(LOW)
-            .noClasses().should().setFieldWhere(TARGET_IS_COLUMN);
+            .noClasses().should().accessFieldWhere(TARGET_IS_COLUMN);
 
     /**
      * False Positive. @Generated value is set to Retention.RUNTIME, so should be OK?
@@ -68,7 +68,7 @@ public class JavaxPersistenceTests {
      */
     @ArchTest
     public static final ArchRule noGeneratedValues = ArchRuleDefinition.priority(LOW)
-            .noClasses().should().setFieldWhere(TARGET_IS_GENERATED_VALUE);
+            .noClasses().should().accessFieldWhere(TARGET_IS_GENERATED_VALUE);
 
 
     /**
@@ -77,7 +77,7 @@ public class JavaxPersistenceTests {
      */
     @ArchTest
     public static final ArchRule noPersistenceUnits = ArchRuleDefinition.priority(LOW)
-            .noClasses().should().setFieldWhere(TARGET_IS_PERSISTENCE_UNIT);
+            .noClasses().should().accessFieldWhere(TARGET_IS_PERSISTENCE_UNIT);
 
 
 }


### PR DESCRIPTION
I added an example, how you could also check for member annotations. Since what you probably want, is to forbid any field / method annotated with a certain type?
I should add something like this to the ArchUnit examples at some point...